### PR TITLE
Fix IP address resolving logic in hosted environments

### DIFF
--- a/components/org.wso2.carbon.identity.fraud.detection.sift/src/main/java/org/wso2/carbon/identity/fraud/detection/sift/util/Util.java
+++ b/components/org.wso2.carbon.identity.fraud.detection.sift/src/main/java/org/wso2/carbon/identity/fraud/detection/sift/util/Util.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.context.TransientObjectWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.fraud.detection.sift.Constants;
 import org.wso2.carbon.identity.fraud.detection.sift.internal.SiftDataHolder;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
@@ -39,6 +40,7 @@ import org.wso2.carbon.identity.governance.bean.ConnectorConfig;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.JS_CURRENT_KNOWN_SUBJECT;
@@ -312,9 +314,9 @@ public class Util {
 
         Object httpServletRequest = ((TransientObjectWrapper<?>) context.getWrapped().getParameter
                 (HTTP_SERVLET_REQUEST)).getWrapped();
-        if (httpServletRequest instanceof HttpServletRequestWrapper) {
-            HttpServletRequestWrapper authenticationFrameworkWrapper = (HttpServletRequestWrapper) httpServletRequest;
-            return authenticationFrameworkWrapper.getRemoteAddr();
+        if (httpServletRequest instanceof HttpServletRequest) {
+            HttpServletRequest request = (HttpServletRequest) httpServletRequest;
+            return IdentityUtil.getClientIpAddress(request);
         }
         return null;
     }


### PR DESCRIPTION
When forwarded IP addresses are sent in requests, the newly introduced logic will resolve the forwarded IP instead of the default remoteAddress of the request.

Related issue:
- https://github.com/wso2/product-is/issues/26265