### PR TITLE
Resolve user or admin status from IdentityContext

### DIFF
--- a/components/org.wso2.carbon.identity.fraud.detection.sift/src/main/java/org/wso2/carbon/identity/fraud/detection/sift/util/SiftUpdatePasswordEventUtil.java
+++ b/components/org.wso2.carbon.identity.fraud.detection.sift/src/main/java/org/wso2/carbon/identity/fraud/detection/sift/util/SiftUpdatePasswordEventUtil.java
@@ -256,7 +256,7 @@ public class SiftUpdatePasswordEventUtil {
             if (FORCED_RESET.getValue().equals(reason)) {
                 isActionPerformedByAdmin = true;
             }
-        } else if (SUCCESS.getValue().equals(reason)) {
+        } else if (SUCCESS.getValue().equals(status)) {
             if (FORCED_RESET.getValue().equals(reason) && POST_CREDENTIAL_UPDATE_BY_ADMIN.equals(scenario)) {
                 isActionPerformedByAdmin = true;
             }

--- a/components/org.wso2.carbon.identity.fraud.detection.sift/src/main/java/org/wso2/carbon/identity/fraud/detection/sift/util/SiftUserProfileUpdateEventUtil.java
+++ b/components/org.wso2.carbon.identity.fraud.detection.sift/src/main/java/org/wso2/carbon/identity/fraud/detection/sift/util/SiftUserProfileUpdateEventUtil.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.fraud.detection.sift.util;
 import com.siftscience.exception.InvalidFieldException;
 import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.UpdateAccountFieldSet;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.fraud.detection.core.constant.FraudDetectionConstants;
 import org.wso2.carbon.identity.fraud.detection.core.exception.IdentityFraudDetectionRequestException;
 import org.wso2.carbon.identity.fraud.detection.core.exception.IdentityFraudDetectionResponseException;
@@ -31,9 +33,6 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.Map;
 
-import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.SCENARIO;
-import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.Scenario.ScenarioTypes.POST_USER_PROFILE_UPDATE_BY_ADMIN;
-import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.Scenario.ScenarioTypes.POST_USER_PROFILE_UPDATE_BY_USER;
 import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.fraud.detection.sift.Constants.USER_PROFILE_UPDATED_BY_ADMIN;
 import static org.wso2.carbon.identity.fraud.detection.sift.Constants.USER_UUID;
@@ -76,7 +75,7 @@ public class SiftUserProfileUpdateEventUtil {
                     .setName(resolveFullName(properties))
                     .setBrowser(resolveBrowser(resolveUserAgent(properties)))
                     .setIp(resolveRemoteAddress(properties))
-                    .setCustomField(USER_PROFILE_UPDATED_BY_ADMIN, isProfileUpdateByAdmin(properties))
+                    .setCustomField(USER_PROFILE_UPDATED_BY_ADMIN, isProfileUpdateByAdmin())
                     .setCustomField(USER_UUID, resolveUserUUID(properties));
             fieldSet.validate();
             return setAPIKey(fieldSet, tenantDomain);
@@ -110,22 +109,25 @@ public class SiftUserProfileUpdateEventUtil {
     /**
      * Determines if the profile update was performed by an admin.
      *
-     * @param properties Map of event properties.
      * @return true if updated by admin, false if by user.
      * @throws IdentityFraudDetectionRequestException if the scenario is invalid.
      */
-    private static boolean isProfileUpdateByAdmin(Map<String, Object> properties)
-            throws IdentityFraudDetectionRequestException {
+    private static boolean isProfileUpdateByAdmin() throws IdentityFraudDetectionRequestException {
 
-        String scenario = (String) properties.get(SCENARIO);
-        if (POST_USER_PROFILE_UPDATE_BY_ADMIN.equals(scenario)) {
-            return true;
-        } else if (POST_USER_PROFILE_UPDATE_BY_USER.equals(scenario)) {
-            return false;
+        if (IdentityContext.getThreadLocalIdentityContext().getCurrentFlow().getInitiatingPersona() == null) {
+            throw new IdentityFraudDetectionRequestException("Unable to determine profile update initiator. " +
+                    "Initiating persona is null in the current flow.");
         }
 
-        throw new IdentityFraudDetectionRequestException("Unable to determine profile update initiator. " +
-                "Invalid scenario: " + scenario);
+        String persona = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow().getInitiatingPersona().name();
+        if (Flow.InitiatingPersona.ADMIN.name().equalsIgnoreCase(persona)) {
+            return true;
+        } else if (Flow.InitiatingPersona.USER.name().equalsIgnoreCase(persona)) {
+            return false;
+        } else {
+            throw new IdentityFraudDetectionRequestException("Unable to determine profile update initiator. " +
+                    "Invalid initiating persona: " + persona);
+        }
     }
 
 }


### PR DESCRIPTION
This pull request refactors the logic used to determine whether a user profile update was performed by an admin or a user, shifting from a scenario-based approach to utilizing the `IdentityContext` and `Flow` model for more accurate identification. It also updates related method signatures and usages to align with this new approach.

Improvements to admin/user identification logic:

* The `isProfileUpdateByAdmin` method now uses the `IdentityContext` and `Flow` classes to determine the initiating persona, rather than relying on event scenario strings. This enhances reliability and future extensibility.
* Error handling has been improved in `isProfileUpdateByAdmin` to throw exceptions when the initiating persona is null or invalid, making failures more explicit and easier to debug.

Code usage and signature updates:

* The call to `isProfileUpdateByAdmin` in `handlePostUserProfileUpdateEventPayload` was updated to remove the properties argument, reflecting the new method signature.
* Imports for `IdentityContext` and `Flow` were added to support the new logic.
* Unused scenario-related imports were removed, since the logic no longer depends on event scenario constants.