### PR TITLE
Add latest java21 supported version to connector store

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -52,6 +52,13 @@
       "tagName": "v4.0.0",
       "products": [
         "IS 7.2.0"
+      ],
+      "isHidden": true
+    },
+    {
+      "tagName": "v4.1.2",
+      "products": [
+        "IS 7.3.0"
       ]
     }
   ]


### PR DESCRIPTION
This pull request updates the `.connector-store/meta.json` file to add support for a new product version and to hide an existing version from visibility.

Version management updates:

* Added a new entry for version `v4.1.2`, associating it with the product `IS 7.3.0`.
* Marked the existing version `v4.0.0` as hidden by adding the `isHidden: true` property.